### PR TITLE
Detail fixing (margins, paddings, whitespace)

### DIFF
--- a/src/lib/molecules/Heading.svelte
+++ b/src/lib/molecules/Heading.svelte
@@ -18,6 +18,9 @@
     letter-spacing: -0.04em;
     margin: 0;
     font-weight: 600;
+    font-size: 2.25rem;
+    padding: 0.25rem;
+    padding-left: .5rem;
   }
 
   h2 > strong {

--- a/src/lib/molecules/Program.svelte
+++ b/src/lib/molecules/Program.svelte
@@ -26,7 +26,7 @@
     }
   }
   :global(section h2::selection, section p::selection) { background-color: var(--lavender); color: var(--lavender); }
-  :global(section h2) { font-size: 2.25rem; padding: 0.25em; padding-left: 1rem; }
+  :global(h2) { font-size: 2.25rem; padding: 0.25rem; padding-left: .5rem; }
   :global(section p) { padding: 0 0.75em; font-size: 1rem; margin: 0; max-width: 65ch; letter-spacing: -0.04em; }
   @media (min-width: 750px) { div { width: max-content; } }
 </style>

--- a/src/lib/molecules/Program.svelte
+++ b/src/lib/molecules/Program.svelte
@@ -26,7 +26,6 @@
     }
   }
   :global(section h2::selection, section p::selection) { background-color: var(--lavender); color: var(--lavender); }
-  :global(h2) { font-size: 2.25rem; padding: 0.25rem; padding-left: .5rem; }
   :global(section p) { padding: 0 0.75em; font-size: 1rem; margin: 0; max-width: 65ch; letter-spacing: -0.04em; }
   @media (min-width: 750px) { div { width: max-content; } }
 </style>

--- a/src/lib/molecules/Program.svelte
+++ b/src/lib/molecules/Program.svelte
@@ -27,9 +27,6 @@
   }
   :global(section h2::selection, section p::selection) { background-color: var(--lavender); color: var(--lavender); }
   :global(section h2) { font-size: 2.25rem; padding: 0.25em; padding-left: 1rem; }
-  :global(section p) {
-    padding: 0 0.75em; font-size: 1rem; margin: 0;
-    max-width: 65ch; letter-spacing: -0.04em;
-  }
+  :global(section p) { padding: 0 0.75em; font-size: 1rem; margin: 0; max-width: 65ch; letter-spacing: -0.04em; }
   @media (min-width: 750px) { div { width: max-content; } }
 </style>

--- a/src/lib/molecules/Semester.svelte
+++ b/src/lib/molecules/Semester.svelte
@@ -18,6 +18,7 @@
     padding: 0;
     border: none;
     scroll-snap-align: start;
+    margin-left: -.15em;
   }
 
   .semester a {
@@ -34,7 +35,7 @@
     list-style: none;
     padding: 0.5rem;
     margin-top: -1em;
-    width: 360px;
+    width: 320px;
   }
 
   :global(.semester h2) {
@@ -56,5 +57,9 @@
     }
 
     .semester > a:focus { color: var(--blueberry); }
+
+    ol{
+      width: 360px;
+    }
   }
 </style>

--- a/src/lib/molecules/Semester.svelte
+++ b/src/lib/molecules/Semester.svelte
@@ -34,7 +34,8 @@
   ol {
     list-style: none;
     padding: 0.5rem;
-    margin-top: -1em;
+    margin-top: -1.5em;
+    margin-left: -.25em;
     width: 320px;
   }
 
@@ -55,8 +56,6 @@
       text-decoration: none;
       display: inline-block;
     }
-
-    .semester > a:focus { color: var(--blueberry); }
 
     ol{
       width: 360px;

--- a/src/lib/molecules/Semester.svelte
+++ b/src/lib/molecules/Semester.svelte
@@ -34,7 +34,7 @@
     list-style: none;
     padding: 0.5rem;
     margin-top: -1em;
-    width: 350px;
+    width: 360px;
   }
 
   :global(.semester h2) {
@@ -56,10 +56,5 @@
     }
 
     .semester > a:focus { color: var(--blueberry); }
-
-    ol {
-      list-style: none;
-      width: 85%;
-    }
   }
 </style>

--- a/src/lib/molecules/Semester.svelte
+++ b/src/lib/molecules/Semester.svelte
@@ -24,6 +24,7 @@
     color: var(--blueberry);
     text-decoration: none;
     display: inline-block;
+    font-size: 1.5em;
     margin: 0 -0.5rem 0.5rem;
   }
 

--- a/src/lib/molecules/Topics.svelte
+++ b/src/lib/molecules/Topics.svelte
@@ -22,23 +22,26 @@
 </aside>
 
 <style>
-  aside ul {
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-wrap: wrap;
-    column-gap: 0.25rem;
-    row-gap: 0.25rem;
-  }
+  aside {
+    padding-left: .5rem;
 
-  aside ul li {
-    padding: 0.1rem .25rem;
-    font-size: 0.8rem;
-    font-weight: 600;
-    border-radius: var(--rounded);
-    line-height: 1.5;
-    display: flex;
-    background: var(--turquoise);
-    color: black;
+    ul {
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-wrap: wrap;
+      column-gap: 0.25rem;
+      row-gap: 0.25rem;
+      li {
+        padding: 0.1rem .25rem;
+        font-size: 0.8rem;
+        font-weight: 600;
+        border-radius: var(--rounded);
+        line-height: 1.5;
+        display: flex;
+        background: var(--turquoise);
+        color: black;
+      }
+    }
   }
 </style>

--- a/src/lib/organisms/ContentSemester.svelte
+++ b/src/lib/organisms/ContentSemester.svelte
@@ -14,6 +14,7 @@
 <style>
   article {
     margin-block: 2rem;
+    margin-inline: 0.5rem;
     padding: 1rem;
     background-color: var(--white);
     border: 2px solid var(--turquoise);

--- a/src/lib/organisms/ContentSprint.svelte
+++ b/src/lib/organisms/ContentSprint.svelte
@@ -30,6 +30,6 @@
   }
 
   article div { margin-top: 1.5rem; }
-  :global(article p) { font-size: 1rem; }
+  :global(article p) { font-size: 1rem; padding-left: .5rem;}
   :global(blockquote) { font-size: 1rem; }
 </style>

--- a/src/lib/organisms/Nav.svelte
+++ b/src/lib/organisms/Nav.svelte
@@ -64,6 +64,7 @@
         letter-spacing: -0.03em;
         font-size: 0.9rem;
         margin-left: 0.25em;
+        display: none;
       }
       p::before { content: unset; }
     }
@@ -123,7 +124,7 @@
   @media (760px <= width) {
     header {
       .top { .hva-logo { width: 40%; }
-        p { margin-left: 1em; font-size: 1rem; }
+        p { margin-left: 1em; font-size: 1rem; display: block; }
         p::before {
           content: "";
           position: absolute;

--- a/src/lib/organisms/Schedule.svelte
+++ b/src/lib/organisms/Schedule.svelte
@@ -97,7 +97,7 @@
   }
 
   section > :global(h2) {
-    padding-bottom: 0;
+    padding: 0;
   }
 
   .week-container { padding: 2rem 0 2rem 0; }

--- a/src/lib/organisms/Semesters.svelte
+++ b/src/lib/organisms/Semesters.svelte
@@ -13,12 +13,7 @@
   {#if jsEnabled}
     <form class="agenda-container">
       <label for="show-hide-dates">
-        <input
-          type="checkbox"
-          id="show-hide-dates"
-          class="pacman"
-          onchange={toggleDates}
-        />
+        <input type="checkbox" id="show-hide-dates" class="pacman" onchange={toggleDates}/>
         Show/hide full agenda
       </label>
     </form>
@@ -32,20 +27,33 @@
 </section>
 
 <style>
+  form {
+
+    label{
+      display: flex;
+      flex-direction: column;
+
+      input{
+        
+      }
+    }
+  } 
+
   @keyframes waka_waka_waka { to { transform: translate(-50%, var(--translation)) rotate(var(--rotation)); } }
+
   .pacman {
     appearance: none;
     position: relative;
     font-size: 1.5em;
     width: 3em;
-    margin-left: 1em;
+    margin-left: -0.15em;
     aspect-ratio: 3;
     border: max(1px, 0.05em) solid #fff;
     border-radius: 2em;
     box-sizing: content-box;
     background: linear-gradient(90deg, var(--lavender) 6em, #1230 0) -5.5em 0 / 9em 100%, radial-gradient(circle, #fff 0.075em, #fff0 0.08em) 50% 0 / 0.4em 100%, var(--lavender);
     transition: background-position calc(var(--speed) * 4) linear;
-    --waka-speed: 0.2s;
+    --waka-speed: 0.4s;
     --speed: 0.5s;
   }
 
@@ -78,10 +86,7 @@
   .pacman:checked::after { --rotation: 30deg; }
 
   @media (prefers-reduced-motion: reduce) {
-    .pacman::before,
-    .pacman::after {
-      animation: none;
-    }
+    .pacman::before, .pacman::after { animation: none; }
   }
 
   section {
@@ -90,7 +95,9 @@
     background: var(--grey);
     color: var(--blueberry);
   }
-  h2 { margin: 0; padding: 3rem 1.25rem 1.5rem; }
+
+  h2 { margin: 0; padding: 3rem .25rem 1.5rem; }
+
   .semester-grid {
     display: flex;
     flex-direction: row;
@@ -99,17 +106,16 @@
     scroll-snap-type: x mandatory;
     padding: 1rem 1rem 2rem 0rem;
   }
+
   label {
     color: var(--blueberry);
     font-size: 0.7rem;
     font-weight: 600;
     margin-left: 0.8rem;
   }
-  @media (min-width: 600px) {
-    .semester-grid {
-      gap: 3rem;
-    }
-  }
+
+  @media (min-width: 600px) { .semester-grid { gap: 3rem; } }
+
   @media (min-width: 1250px) {
     .semester-grid {
       display: grid;
@@ -117,6 +123,7 @@
       gap: 3rem;
       padding: 2rem 1rem 2rem 1rem;
     }
+
     h2 { padding-left: 2rem; }
   }
 </style>

--- a/src/lib/organisms/Semesters.svelte
+++ b/src/lib/organisms/Semesters.svelte
@@ -27,25 +27,33 @@
 </section>
 
 <style>
-  form {
+  @keyframes waka_waka_waka { to { transform: translate(-50%, var(--translation)) rotate(var(--rotation)); } }
 
+  section {
+    position: relative;
+    padding: 0;
+    background: var(--grey);
+    color: var(--blueberry);
+  }
+
+  h2 { margin: 0; padding: 3rem .1rem 1.5rem; }
+
+  form {
     label{
       display: flex;
       flex-direction: column;
-
-      input{
-        
-      }
+      color: var(--blueberry);
+      font-size: 0.7rem;
+      font-weight: 700;
+      margin-left: 0.15rem;
     }
-  } 
-
-  @keyframes waka_waka_waka { to { transform: translate(-50%, var(--translation)) rotate(var(--rotation)); } }
+  
 
   .pacman {
     appearance: none;
     position: relative;
     font-size: 1.5em;
-    width: 3em;
+    width: 3.5em;
     margin-left: -0.15em;
     aspect-ratio: 3;
     border: max(1px, 0.05em) solid #fff;
@@ -62,7 +70,7 @@
     --translation: -100%;
     content: "";
     position: absolute;
-    width: 0.8em;
+    width: 0.7em;
     height: 0.4em;
     background: yellow;
     border-radius: 50% / 100% 100% 0 0;
@@ -84,43 +92,23 @@
   .pacman:checked { background-position: 2.5em 0, 50% 0; }
   .pacman:checked::before, .pacman:checked::after { --rotation: -30deg; left: calc(100% - 0.5em); }
   .pacman:checked::after { --rotation: 30deg; }
-
-  @media (prefers-reduced-motion: reduce) {
-    .pacman::before, .pacman::after { animation: none; }
   }
-
-  section {
-    position: relative;
-    padding: 0;
-    background: var(--grey);
-    color: var(--blueberry);
-  }
-
-  h2 { margin: 0; padding: 3rem .25rem 1.5rem; }
 
   .semester-grid {
     display: flex;
     flex-direction: row;
     overflow: scroll;
-    gap: 2.75em;
+    gap: 1.75em;
     scroll-snap-type: x mandatory;
     padding: 1rem 1rem 2rem 0rem;
   }
 
-  label {
-    color: var(--blueberry);
-    font-size: 0.7rem;
-    font-weight: 600;
-    margin-left: 0.8rem;
-  }
-
-  @media (min-width: 600px) { .semester-grid { gap: 3rem; } }
+  @media (prefers-reduced-motion: reduce) { .pacman::before, .pacman::after { animation: none; } }
 
   @media (min-width: 1250px) {
     .semester-grid {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-      gap: 3rem;
       padding: 2rem 1rem 2rem 1rem;
     }
 

--- a/src/lib/organisms/Semesters.svelte
+++ b/src/lib/organisms/Semesters.svelte
@@ -109,9 +109,9 @@
     .semester-grid {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-      padding: 2rem 1rem 2rem 1rem;
+      padding: 2rem 0rem 2rem 0rem;
     }
 
-    h2 { padding-left: 2rem; }
+    h2 { padding-left: 0rem; }
   }
 </style>

--- a/src/lib/organisms/Semesters.svelte
+++ b/src/lib/organisms/Semesters.svelte
@@ -100,7 +100,7 @@
     overflow: scroll;
     gap: 1.75em;
     scroll-snap-type: x mandatory;
-    padding: 1rem 1rem 2rem 0rem;
+    padding: 1rem 0 2rem 0;
   }
 
   @media (prefers-reduced-motion: reduce) { .pacman::before, .pacman::after { animation: none; } }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -25,24 +25,20 @@
 <style>
   :global(body) { margin: 0 0.75em; background-color: var(--lavender); }
   :global(body), :global(body main) { display: block; }
+
   :global(main) {
     background-color: var(--grey);
-    max-width: var(--max-width);
     padding: 0 1rem 0 1rem;
     border-radius: var(--rounded);
   }
-  :global(footer) {
-    margin: auto;
-    margin-top: 1rem;
-    max-width: var(--max-width);
-  }
+
+  :global(footer) { margin: auto; margin-top: 1rem; }
   :global(footer nav) { padding: 1rem; }
   :global(footer nav h2) { margin: calc(-1rem - 1px) calc(-1rem - 1px) 1rem 2rem; }
   :global(footer nav p), :global(footer nav ul) { margin-left: 0.5rem; }
   @media (min-width: 750px) {
     :global(main) {
       background-color: var(--grey);
-      max-width: var(--max-width);
       padding: 0 2rem 0 2rem;
       border-radius: var(--rounded);
     }

--- a/src/routes/[semester]/+page.svelte
+++ b/src/routes/[semester]/+page.svelte
@@ -43,7 +43,6 @@
         display: flex;
         flex-direction: row;
         justify-content: space-between;
-        flex-wrap: wrap;
       }
     }
   }

--- a/src/routes/[semester]/+page.svelte
+++ b/src/routes/[semester]/+page.svelte
@@ -8,9 +8,7 @@
   const semester = data;
 </script>
 
-<div>
-  <Heading title="Semester" subtitle={semester.title}/>
-</div>
+<Heading title="Semester" subtitle={semester.title}/>
 <section>
   <div class="content-container">
     <Content {semester} />
@@ -26,16 +24,13 @@
 </section>
 
 <style>
-  div{ padding-top: 3rem; }
-
   section{
     display: flex;
     flex-direction: column;
 
     .content-container{ width: 100%; }
     article{
-      h3{ margin-left: 2em; }
-      ol{ width: 90%; }
+      ol{ padding-left: 0; }
     }
   }
 
@@ -50,10 +45,6 @@
         justify-content: space-between;
         flex-wrap: wrap;
       }
-
-      article{
-        h3{ margin-left: 2em; }
-      }
     }
   }
 
@@ -64,8 +55,10 @@
       grid-template-columns: 2fr 1fr;
 
       .content-container{ grid-area: content; }
+      
       article{
-        h3{ margin-left: 2em; }
+        padding-left: 3em;
+        padding-bottom: 1em;
         ol{ grid-area: sprints; }
       }
     }

--- a/src/routes/[semester]/[sprint]/+page.svelte
+++ b/src/routes/[semester]/[sprint]/+page.svelte
@@ -24,7 +24,7 @@
     gap: 2rem;
     background-color: var(--grey);
     border-radius: var(--rounded) 0 0 0;
-    padding: 3rem 0 1rem 0;
+    padding: 3rem 0 2rem 0;
   }
 
   @media (min-width: 40em) {

--- a/src/routes/[semester]/[sprint]/+page.svelte
+++ b/src/routes/[semester]/[sprint]/+page.svelte
@@ -24,7 +24,7 @@
     gap: 2rem;
     background-color: var(--grey);
     border-radius: var(--rounded) 0 0 0;
-    padding: 3rem 0 2rem 0;
+    padding: 3rem 0 1rem 0;
   }
 
   @media (min-width: 40em) {


### PR DESCRIPTION
### Pull request information
While I still have a bug with the `<section class=semester>` being overlapped by the `<main>` padding, the whole website now has evenly spaced and aligned elements throughout.

The overall look now is universalized with its paddings, margins and whitespace.

> NOTE: This branch was NOT updated before the screenshots, so some parts might look different, however the main issue that can be closed with this pull request is NOT influenced by these changes 

### Issues I've Worked on:
- [Sprint review issue](https://github.com/users/KaanKalmi/projects/14?pane=issue&itemId=88876941&issue=KaanKalmi%7Cdont-repeat-yourself-component-library%7C70)

### Before and after:
Homepage:
> before
![image](https://github.com/user-attachments/assets/5ca3aad0-7552-4a5b-84e7-49c467d6aa57)
![image](https://github.com/user-attachments/assets/ed33d045-7595-46c2-a53a-770ce850ad30)
![image](https://github.com/user-attachments/assets/aa761882-cdcb-4926-ad98-055799efb3db)

> after
![image](https://github.com/user-attachments/assets/a59dbbae-773f-456c-a409-0c65bfe3ea05)
![image](https://github.com/user-attachments/assets/8aebfdd3-2ea1-44b1-863c-cd9b17955b40)
![image](https://github.com/user-attachments/assets/f4129cf5-7073-484d-a8ee-c1cb19d6750e)


Semester page:
> before
![image](https://github.com/user-attachments/assets/8892d634-f41c-41f5-be0f-543e5a428433)
![image](https://github.com/user-attachments/assets/41ba2efc-0a43-494c-991f-6d0ea210de41)
![image](https://github.com/user-attachments/assets/540e3ee5-0cc0-4920-a212-3ef24101a2be)

> after
![image](https://github.com/user-attachments/assets/e310fa53-acc3-4c4f-9d03-338ed28cfd8c)
![image](https://github.com/user-attachments/assets/2abac2e1-35b1-4205-91e4-1c56a333cbe0)
![image](https://github.com/user-attachments/assets/55f27c18-7513-4fdd-a6ff-eb2782d6d512)

Sprint page:
> before
![image](https://github.com/user-attachments/assets/77cbbddf-1393-4062-8830-96d56f1609dd)
![image](https://github.com/user-attachments/assets/b3e87a03-96f6-4f1e-b78d-14e6031e793d)
![image](https://github.com/user-attachments/assets/7395ba5b-65c3-458e-b97b-50ed60b66798)

> after
![image](https://github.com/user-attachments/assets/d24361a0-fb1d-4686-9f13-6f1b7a9577b1)
![image](https://github.com/user-attachments/assets/fc4f29ab-8b26-431d-9d7f-e41693881d5d)
![image](https://github.com/user-attachments/assets/dc9ce130-9f45-4f82-89ef-efc054ef875f)

### Tests I've ran:
Lighthouse test results, 3rd result of the 5 have shown these scores:

![image](https://github.com/user-attachments/assets/29043b0d-bdf1-4929-8a1a-d19163266a6c)
![image](https://github.com/user-attachments/assets/c9cdbe4d-1068-4e68-b411-5b34e768db03)
![image](https://github.com/user-attachments/assets/d13ffdec-9431-4572-a586-6b42193112d5)